### PR TITLE
Upgrade to js-tokens@3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var chalk           = require('chalk');
-var jsTokensRe      = require('js-tokens');
+var jsTokens        = require('js-tokens');
 var isES2016Keyword = require('is-es2016-keyword');
+
+var jsTokensRe = jsTokens.default;
+var matchToToken = jsTokens.matchToToken;
 
 var NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
 
@@ -23,7 +26,7 @@ module.exports = function highlight (src, renderer) {
         for (var i = 0; i < arguments.length; i++)
             match.push(arguments[i]);
 
-        var token = jsTokensRe.matchToToken(match);
+        var token = matchToToken(match);
 
         if (token.type === 'name' && isES2016Keyword(value, true))
             token.type = 'keyword';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "is-es2016-keyword": "^1.0.0",
-    "js-tokens": "^1.0.2"
+    "js-tokens": "^3.0.0"
   }
 }


### PR DESCRIPTION
This brings ES2016 support and a big [performance boost](https://github.com/lydell/js-tokens/blob/master/CHANGELOG.md#version-300-2017-01-11).